### PR TITLE
Fix CVE-2021-45046 risk in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,9 +45,9 @@ dependencies {
     integrationTestImplementation 'org.testcontainers:junit-jupiter:1.16.0'
     integrationTestImplementation 'org.testcontainers:kafka:1.16.0'
     integrationTestImplementation 'org.testcontainers:toxiproxy:1.16.0'
-    integrationTestImplementation 'com.solace.test.integration:pubsubplus-junit-jupiter:0.7.0'
+    integrationTestImplementation 'com.solace.test.integration:pubsubplus-junit-jupiter:0.7.1'
     integrationTestImplementation 'org.slf4j:slf4j-api:1.7.32'
-    integrationTestImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
+    integrationTestImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
     integrationTestImplementation 'org.apache.commons:commons-configuration2:2.6'
     integrationTestImplementation 'commons-beanutils:commons-beanutils:1.9.4'
     integrationTestImplementation 'com.google.code.gson:gson:2.3.1'
@@ -57,7 +57,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testImplementation 'org.mockito:mockito-junit-jupiter:3.12.4'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'
-    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.14.1'
+    testImplementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
     compile "org.apache.kafka:connect-api:$kafkaVersion"
     compile "com.solacesystems:sol-jcsmp:$solaceJavaAPIVersion"
 }


### PR DESCRIPTION
Upgrade log4j to 2.16.0 in tests to fix CVE-2021-45046 risks.